### PR TITLE
feat: add no-commit-to-branch hook and test

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,7 @@ repos:
     -   id: check-yaml
     -   id: check-toml
     -   id: check-added-large-files
+    -   id: no-commit-to-branch
 
 -   repo: https://github.com/psf/black
     rev: 24.3.0 # Use a recent version compatible with your pyproject.toml

--- a/README.md
+++ b/README.md
@@ -65,3 +65,4 @@ Communication with Cursor is facilitated through a defined MCP interface, allowi
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+# Adding a newline for testing pre-commit hook


### PR DESCRIPTION
Add pre-commit hook to prevent direct commits to main
Description:
This PR introduces a no-commit-to-branch pre-commit hook to safeguard the main branch from direct commits. This encourages a pull request-based workflow, ensuring all changes to main are reviewed.
Changes:
Added the no-commit-to-branch hook from pre-commit-hooks to .pre-commit-config.yaml.
(Includes a minor test modification to README.md that was used to verify the hook's functionality during development - this can be reverted if desired before merging, or kept as a record of the test).
Testing:
Attempted to commit directly to main after installing the hook; the commit was successfully blocked.
Committed changes to a feature branch (test/prevent-main-commit) successfully.
This helps maintain the integrity of the main branch and aligns with standard development best practices.